### PR TITLE
The card router still required the mtgsdk

### DIFF
--- a/router/card.js
+++ b/router/card.js
@@ -1,5 +1,4 @@
 const express = require('express');
-const { card } = require('mtgsdk');
 const router = express.Router();
 
 const cardController = require('../controllers/cardController');


### PR DESCRIPTION
The express server wouldn't start due to a leftover require statement. 

Closes: #5 